### PR TITLE
Telephone link

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -22,6 +22,7 @@
     <link href="/css/style.css" media="screen" rel="stylesheet">
     <link href="http://fonts.googleapis.com/css?family=Source+Code+Pro:200,300,400,500,700" rel="stylesheet">
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+    <meta name="format-detection" content="telephone=no">
     <script src="http://maps.google.com/maps/api/js?sensor=false"></script>
     <script src="/js/lib/react-with-addons.js"></script>
     <script src="/js/lib/immutable.min.js"></script>

--- a/about/index.html
+++ b/about/index.html
@@ -74,9 +74,11 @@
           <h1>CONTACT</h1>
           <ul>
             <li>401 3-3-32 Sendagaya, Shibuya, Tokyo<br>151-0051 JAPAN</li>
-            <li>P: +81(0)3 6890 0775</li>
+            <li>P: <a href="tel:0368900775">+81(0)3 6890 0775</a>
+            </li>
             <li>F: +81(0)3 6890 0776</li>
-            <li>M:<a href="mailto:info&#64;ranagram.com">info&#64;ranagram.com</a></li>
+            <li>M: <a href="mailto:info&#64;ranagram.com">info&#64;ranagram.com</a>
+            </li>
           </ul>
         </section>
         <section class="group">

--- a/src/jade/about/index.jade
+++ b/src/jade/about/index.jade
@@ -1,6 +1,7 @@
 extends ../_base
 
 block script_before
+  meta(name="format-detection" content="telephone=no")
   script(src="http://maps.google.com/maps/api/js?sensor=false")
 
 block content

--- a/src/jade/about/index.jade
+++ b/src/jade/about/index.jade
@@ -34,9 +34,12 @@ block content
       li 401 3-3-32 Sendagaya, Shibuya, Tokyo
         br
         | 151-0051 JAPAN
-      li P: +81(0)3 6890 0775
+      li
+        = 'P: '
+        a(href="tel:0368900775") +81(0)3 6890 0775
       li F: +81(0)3 6890 0776
-      li M:
+      li
+        = 'M: '
         a(href!="mailto:info&#64;ranagram.com") info&#64;ranagram.com
 
   section.group


### PR DESCRIPTION
@chutaicho 
とあるユーザーさんより、iPhoneでAboutページから直接電話がかけられない、というフィードバックがありました。（フォーマットが英語表記のため）
電話番号表記はそのままで、リンク先のみを日本の電話番号フォーマットに修正しました。
問題なければマージをお願いいたします。

![2016-09-01 18 08 38](https://cloud.githubusercontent.com/assets/958890/18162879/31ad7954-7073-11e6-8eb2-e4b1b6bc05c6.png)
